### PR TITLE
Add optional storing of original datastream.

### DIFF
--- a/modules/islandora_xslt_populator/includes/admin.form.inc
+++ b/modules/islandora_xslt_populator/includes/admin.form.inc
@@ -13,6 +13,9 @@ function islandora_xslt_populator_admin_form($form, &$form_state) {
   form_load_include($form_state, 'inc', 'islandora_xslt_populator', 'includes/admin.form');
   $populators = islandora_xslt_populator_get_populators();
   foreach ($populators as &$populator) {
+    if (is_null($populator['original_dsid'])) {
+      $populator['original_dsid'] = t('Not storing original.');
+    }
     $populator['description'] = check_plain($populator['description']);
     $populator['xslt'] = theme('file_link', array(
       'file' => file_load($populator['xslt']),
@@ -36,6 +39,7 @@ function islandora_xslt_populator_admin_form($form, &$form_state) {
           'description' => t('Description'),
           'xslt' => t('XSLT File'),
           'datastream_id' => t('Generated Datastream ID'),
+          'original_dsid' => t('Stored Datastream ID'),
           'machine_name' => t('Machine Name'),
         ),
         '#options' => $populators,
@@ -92,6 +96,23 @@ function islandora_xslt_populator_admin_form($form, &$form_state) {
         '#description' => t('A machine name for use in features. If not provided, the relevent configuration will not be available for export in features.'),
         '#required' => FALSE,
       ),
+      'store_original' => array(
+        '#type' => 'checkbox',
+        '#title' => t('Store copy of original file'),
+        '#description' => t('Creates a datastream to store a copy of the original XML file uploaded.'),
+      ),
+      'original_dsid' => array(
+        '#type' => 'textfield',
+        '#title' => t('Original Datastream ID'),
+        '#description' => t('The datastream identifier into which the original file will be stored.'),
+        '#states' => array(
+          'visible' => array(
+            ':input[name="new[store_original]"]' => array(
+              'checked' => TRUE,
+            ),
+          ),
+        ),
+      ),
       'add' => array(
         '#type' => 'submit',
         '#value' => t('Add'),
@@ -135,6 +156,9 @@ function islandora_xslt_populator_admin_form_add_validate(&$form, &$form_state) 
   if (!islandora_is_valid_dsid($form_state['values']['new']['datastream_id'])) {
     form_error($form['new']['datastream_id'], t('The given datastream ID does not appear to be valid.'));
   }
+  if ($form_state['values']['new']['store_original'] && (empty($form_state['values']['new']['original_dsid']) || !islandora_is_valid_dsid($form_state['values']['new']['original_dsid']))) {
+    form_error($form['new']['original_dsid'], t('The given datastream ID does not appear to be valid.'));
+  }
 }
 
 /**
@@ -146,7 +170,8 @@ function islandora_xslt_populator_admin_form_add_submit(&$form, &$form_state) {
     $form_state['values']['new']['description'],
     $form_state['values']['new']['xslt'],
     $form_state['values']['new']['datastream_id'],
-    $form_state['values']['new']['machine_name']
+    $form_state['values']['new']['machine_name'],
+    $form_state['values']['new']['store_original'] ? $form_state['values']['new']['original_dsid'] : NULL
   );
 }
 

--- a/modules/islandora_xslt_populator/includes/db.inc
+++ b/modules/islandora_xslt_populator/includes/db.inc
@@ -65,11 +65,14 @@ function islandora_xslt_populator_remove_populator($ids) {
  *   The datastream ID into which the output should be stored.
  * @param string $machine_name
  *   A name for the populator, to identify in features.
+ * @param NULL|string $original_dsid
+ *   NULL if not storing the original file, string of the DSID to be saved into
+ *   otherwise.
  *
  * @return int
  *   The ID of the populator as it was entered into the database.
  */
-function islandora_xslt_populator_add_populator($title, $description, $xslt, $datastream_id, $machine_name = NULL) {
+function islandora_xslt_populator_add_populator($title, $description, $xslt, $datastream_id, $machine_name = NULL, $original_dsid = NULL) {
   $id = db_insert('islandora_xslt_populator')
     ->fields(array(
       'title' => $title,
@@ -77,6 +80,7 @@ function islandora_xslt_populator_add_populator($title, $description, $xslt, $da
       'xslt' => $xslt,
       'datastream_id' => $datastream_id,
       'machine_name' => $machine_name,
+      'original_dsid' => $original_dsid ? $original_dsid : '',
     ))
     ->execute();
 

--- a/modules/islandora_xslt_populator/includes/db.inc
+++ b/modules/islandora_xslt_populator/includes/db.inc
@@ -80,7 +80,7 @@ function islandora_xslt_populator_add_populator($title, $description, $xslt, $da
       'xslt' => $xslt,
       'datastream_id' => $datastream_id,
       'machine_name' => $machine_name,
-      'original_dsid' => $original_dsid ? $original_dsid : '',
+      'original_dsid' => $original_dsid,
     ))
     ->execute();
 

--- a/modules/islandora_xslt_populator/includes/features.inc
+++ b/modules/islandora_xslt_populator/includes/features.inc
@@ -84,7 +84,8 @@ function islandora_xslt_populator_definitions_features_rebuild($module_name) {
       $info['description'],
       $file->fid,
       $info['datastream_id'],
-      $machine_name
+      $machine_name,
+      isset($info['original_dsid']) ? $info['original_dsid'] : NULL
     );
   }
 }

--- a/modules/islandora_xslt_populator/includes/populate.inc
+++ b/modules/islandora_xslt_populator/includes/populate.inc
@@ -33,6 +33,8 @@ function islandora_xslt_populator_validate_file($element, &$form_state, $form) {
  */
 function islandora_xslt_populator_populate(&$form, &$form_state) {
   $storage =& islandora_ingest_form_get_step_storage($form_state);
+  $object = islandora_ingest_form_get_object($form_state);
+
   // Need to grab the populator definitions to see if we are also storing
   // the original at this point. The XSLT populator module appends an arbitrary
   // string to key the array so replacing that out now to get our database ID.
@@ -43,7 +45,6 @@ function islandora_xslt_populator_populate(&$form, &$form_state) {
   $file = file_load($form_state['values']['file']['fid']);
   if (!is_null($original_dsid)) {
     // Store the original now.
-    $object = islandora_ingest_form_get_object($form_state);
     if (!isset($object[$original_dsid])) {
       $ds = $object->constructDatastream($original_dsid, 'M');
       $ds->label = "$original_dsid Datastream";
@@ -56,8 +57,21 @@ function islandora_xslt_populator_populate(&$form, &$form_state) {
     if ($ds->mimetype != $file->filemime) {
       $ds->mimetype = $file->filemime;
     }
+    $storage['islandora_xslt_populator']['original_dsid'] = $original_dsid;
   }
   return $storage['islandora_xslt_populator']['file'];
+}
+
+/**
+ * Populator callback; depopulate any stored original datastream values.
+ */
+function islandora_xslt_populator_depopulate(&$form, &$form_state) {
+  $storage =& islandora_ingest_form_get_step_storage($form_state);
+  $object = islandora_ingest_form_get_object($form_state);
+  if (isset($storage['islandora_xslt_populator']['original_dsid'])) {
+    $object->purgeDatastream($storage['islandora_xslt_populator']['original_dsid']);
+    unset($storage['islandora_xslt_populator']['original_dsid']);
+  }
 }
 
 /**

--- a/modules/islandora_xslt_populator/includes/populate.inc
+++ b/modules/islandora_xslt_populator/includes/populate.inc
@@ -33,6 +33,30 @@ function islandora_xslt_populator_validate_file($element, &$form_state, $form) {
  */
 function islandora_xslt_populator_populate(&$form, &$form_state) {
   $storage =& islandora_ingest_form_get_step_storage($form_state);
+  // Need to grab the populator definitions to see if we are also storing
+  // the original at this point. The XSLT populator module appends an arbitrary
+  // string to key the array so replacing that out now to get our database ID.
+  // @see: islandora_xslt_islandora_populator().
+  $populators = islandora_xslt_populator_get_populators();
+  $populator_id = str_replace('islandora_xslt_populator--', '', $form_state['islandora']['step_storage']['islandora_populator_select']['selected']);
+  $original_dsid = $populators[$populator_id]['original_dsid'];
+  $file = file_load($form_state['values']['file']['fid']);
+  if (!is_null($original_dsid)) {
+    // Store the original now.
+    $object = islandora_ingest_form_get_object($form_state);
+    if (!isset($object[$original_dsid])) {
+      $ds = $object->constructDatastream($original_dsid, 'M');
+      $ds->label = "$original_dsid Datastream";
+      $object->ingestDatastream($ds);
+    }
+    else {
+      $ds = $object[$original_dsid];
+    }
+    $ds->setContentFromFile(drupal_realpath($file->uri), FALSE);
+    if ($ds->mimetype != $file->filemime) {
+      $ds->mimetype = $file->filemime;
+    }
+  }
   return $storage['islandora_xslt_populator']['file'];
 }
 

--- a/modules/islandora_xslt_populator/includes/populate.inc
+++ b/modules/islandora_xslt_populator/includes/populate.inc
@@ -33,45 +33,14 @@ function islandora_xslt_populator_validate_file($element, &$form_state, $form) {
  */
 function islandora_xslt_populator_populate(&$form, &$form_state) {
   $storage =& islandora_ingest_form_get_step_storage($form_state);
-  $object = islandora_ingest_form_get_object($form_state);
-
-  // Need to grab the populator definitions to see if we are also storing
-  // the original at this point. The XSLT populator module appends an arbitrary
-  // string to key the array so replacing that out now to get our database ID.
-  // @see: islandora_xslt_islandora_populator().
-  $populators = islandora_xslt_populator_get_populators();
-  $populator_id = str_replace('islandora_xslt_populator--', '', $form_state['islandora']['step_storage']['islandora_populator_select']['selected']);
-  $original_dsid = $populators[$populator_id]['original_dsid'];
-  $file = file_load($form_state['values']['file']['fid']);
-  if (!is_null($original_dsid)) {
-    // Store the original now.
-    if (!isset($object[$original_dsid])) {
-      $ds = $object->constructDatastream($original_dsid, 'M');
-      $ds->label = "$original_dsid Datastream";
-      $object->ingestDatastream($ds);
-    }
-    else {
-      $ds = $object[$original_dsid];
-    }
-    $ds->setContentFromFile(drupal_realpath($file->uri), FALSE);
-    if ($ds->mimetype != $file->filemime) {
-      $ds->mimetype = $file->filemime;
-    }
-    $storage['islandora_xslt_populator']['original_dsid'] = $original_dsid;
-  }
   return $storage['islandora_xslt_populator']['file'];
 }
 
 /**
- * Populator callback; depopulate any stored original datastream values.
+ * Populator callback; populate any stored original datastream values.
  */
-function islandora_xslt_populator_depopulate(&$form, &$form_state) {
-  $storage =& islandora_ingest_form_get_step_storage($form_state);
-  $object = islandora_ingest_form_get_object($form_state);
-  if (isset($storage['islandora_xslt_populator']['original_dsid'])) {
-    $object->purgeDatastream($storage['islandora_xslt_populator']['original_dsid']);
-    unset($storage['islandora_xslt_populator']['original_dsid']);
-  }
+function islandora_xslt_populator_populate_original_dsid(&$form, &$form_state) {
+  return file_load($form_state['values']['file']['fid']);
 }
 
 /**

--- a/modules/islandora_xslt_populator/islandora_xslt_populator.install
+++ b/modules/islandora_xslt_populator/islandora_xslt_populator.install
@@ -48,6 +48,12 @@ function islandora_xslt_populator_schema() {
         'length' => 255,
         'not null' => FALSE,
       ),
+      'original_dsid' => array(
+        'type' => 'varchar',
+        'length' => 64,
+        'not null' => FALSE,
+        'default' => NULL,
+      ),
     ),
     'primary key' => array('id'),
     'unique keys' => array(
@@ -62,4 +68,17 @@ function islandora_xslt_populator_schema() {
   );
 
   return $schema;
+}
+
+
+/**
+ * Adds the original_dsid column for optional storing the uploaded file.
+ */
+function islandora_xslt_populator_update_7001(&$sandbox) {
+  db_add_field('islandora_xslt_populator', 'original_dsid', array(
+    'type' => 'varchar',
+    'length' => 64,
+    'not null' => FALSE,
+    'default' => NULL,
+  ));
 }

--- a/modules/islandora_xslt_populator/islandora_xslt_populator.module
+++ b/modules/islandora_xslt_populator/islandora_xslt_populator.module
@@ -32,7 +32,7 @@ function islandora_xslt_populator_islandora_populator() {
   $items = array();
 
   foreach ($populators as $id => $info) {
-    $items["islandora_xslt_populator--$id"] = array(
+    $values = array(
       'title' => t('XSLT Populator: @title', array(
         '@title' => $info['title'],
       )),
@@ -62,13 +62,18 @@ function islandora_xslt_populator_islandora_populator() {
       'output' => array(
         $info['datastream_id'] => array(
           'callback' => 'islandora_xslt_populator_populate',
-          'undo callback' => 'islandora_xslt_populator_depopulate',
         ),
       ),
       'files' => array(
         array('inc', 'islandora_xslt_populator', 'includes/populate'),
       ),
     );
+    if (!is_null($info['original_dsid'])) {
+      $values['output'][$info['original_dsid']] = array(
+        'callback' => 'islandora_xslt_populator_populate_original_dsid',
+      );
+    }
+    $items["islandora_xslt_populator--$id"] = $values;
   }
 
   return $items;

--- a/modules/islandora_xslt_populator/islandora_xslt_populator.module
+++ b/modules/islandora_xslt_populator/islandora_xslt_populator.module
@@ -62,6 +62,7 @@ function islandora_xslt_populator_islandora_populator() {
       'output' => array(
         $info['datastream_id'] => array(
           'callback' => 'islandora_xslt_populator_populate',
+          'undo callback' => 'islandora_xslt_populator_depopulate',
         ),
       ),
       'files' => array(


### PR DESCRIPTION
**Jira:** https://jira.duraspace.org/browse/ISLANDORA-1627 
# What does this Pull Request do?

Adds the ability to create and save the original uploaded file in a datastream when using the XSLT Populator.
# How should this be tested?

Create an XSLT populator configuration.
Check the create original DSID checkbox and enter a DSID for it to go to.
Upload XML to be transformed.
Ingest.
Note that both the original and transformed datastreams are created.
# Additional Notes:
- **Does this change require documentation to be updated?** No.
- **Does this change add any new dependencies?** No.
- **Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)?** Update hook needs to be ran on existing machines as adding a new column to a database table.
- **Could this change impact execution of existing code?** No.

**Tagging:** @Islandora/7-x-1-x-committers as @adam-vessey can't merge this.
## Thanks!

Jordan Dukart
_Developer_
**[discoverygarden inc.](http://www.discoverygarden.ca) | Managing Digital Content**
