### PR TITLE
ISLANDORA-1911 - update links in submodules

### DIFF
--- a/modules/islandora_xslt_populator/README.md
+++ b/modules/islandora_xslt_populator/README.md
@@ -2,13 +2,13 @@
 
 ## Introduction
 
-A plugin for the [Islandora Populator](http://github.com/discoverygarden/islandora_populator) framework to allow the configuration of simple transforms via an adminstrator interface.
+A plugin for the [Islandora Populator](http://github.com/islandora/islandora_populator) framework to allow the configuration of simple transforms via an adminstrator interface.
 
 ## Requirements
 
 This module requires the following modules/libraries:
 
-* [Islandora Populator](http://github.com/discoverygarden/islandora_populator)
+* [Islandora Populator](http://github.com/islandora/islandora_populator)
 
 ## Installation
 
@@ -29,7 +29,7 @@ Having problems or solved a problem? Check out the Islandora google groups for a
 
 Current maintainers:
 
-* [discoverygarden Inc.](https://github.com/discoverygarden)
+* [Jordan Dukart](https://github.com/jordandukart)
 
 ## Development
 

--- a/modules/islandora_xslt_populator/README.md
+++ b/modules/islandora_xslt_populator/README.md
@@ -33,7 +33,7 @@ Current maintainers:
 
 ## Development
 
-If you would like to contribute to this module, please check out our helpful [Documentation for Developers](https://github.com/Islandora/islandora/wiki#wiki-documentation-for-developers) info, as well as our [Developers](http://islandora.ca/developers) section on the Islandora.ca site.
+If you would like to contribute to this module, please check out [CONTRIBUTING.md](CONTRIBUTING.md). In addition, we have helpful [Documentation for Developers](https://github.com/Islandora/islandora/wiki#wiki-documentation-for-developers) info, as well as our [Developers](http://islandora.ca/developers) section on the [Islandora.ca](http://islandora.ca) site.
 
 ## License
 


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1911

# What does this Pull Request do?

Updates submodule to Replace "discoverygarden" with "islandora" in links. Updates submodule Maintainer to match the parent module.

# How should this be tested?

This is just a readme change, so view the changes and verify the links are right and the Maintainer is accurate.

# Interested parties
@jordandukart as Maintainer or @DiegoPino as Release Manager, since this fits into the 7.x-.9 Audit.
