### PR TITLE
7.x islandora populator 1880

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,3 @@ script:
   - $ISLANDORA_DIR/tests/scripts/line_endings.sh sites/all/modules/islandora_populator
   - drush coder-review --reviews=production,security,style,i18n,potx,sniffer sites/all/modules/islandora_populator
   - phpcpd --names *.module,*.inc,*.test,*.php sites/all/modules/islandora_populator
-  - drush test-run --uri=http://localhost:8081 "Islandora Populator"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ before_install:
   - cd $HOME/drupal-*
   - ln -s $TRAVIS_BUILD_DIR sites/all/modules/islandora_populator
   - drush -u 1 en --yes islandora_populator
+  # Mysql might time out for long tests, increase the wait timeout.
+  - mysql -e 'SET @@GLOBAL.wait_timeout=1200'
 script:
   - $ISLANDORA_DIR/tests/scripts/line_endings.sh sites/all/modules/islandora_populator
   - drush coder-review --reviews=production,security,style,i18n,potx,sniffer sites/all/modules/islandora_populator


### PR DESCRIPTION
JIRA Ticket: https://jira.duraspace.org/browse/ISLANDORA-1880

What does this Pull Request do?

Remove Travis-CI Drupal Test invocations made via Drush, which are being deprecated, as there are no tests in this repository. Updates the YAML to have a MySQL timeout so that long running tests don't cause the MySQL session to timeout. Lastly, adds sudo for the YAML as old builds were grandfathered.

What's new?

Removed the from Drush test runner script fro .travis.yml file. Added Sudo in .travis.yml file as it required for the scrips to run, repos before 2015 were grandfathered in. However, this isn't the case for forks. Also, added a before_script in travis.yml file to extend mysql wait time to 1200 as the builds were failing in Travic-ci.org.

Interested parties

@Islandora/7-x-1-x-committers